### PR TITLE
Add task to stop and remove existing Docker containers in playbook

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -21,7 +21,13 @@
         name: docker
         state: started
         enabled: yes
-
+    - name: Stop and remove existing containers
+      shell: |
+        docker-compose down -v
+        docker system prune -f
+      args:
+        chdir: /path/to/app/directory
+      ignore_errors: true
     - name: Create app directory
       file:
         path: /home/ubuntu/qcode


### PR DESCRIPTION
Introduce a task in the playbook to stop and remove existing Docker containers, ensuring a clean environment before deployment.