### PR TITLE
Fix cleanup path for Docker container management in playbook

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -21,13 +21,14 @@
         name: docker
         state: started
         enabled: yes
+
+    # Fix the cleanup path to point to the correct directory
     - name: Stop and remove existing containers
       shell: |
-        docker-compose down -v
+        cd /home/ubuntu/qcode && docker-compose down -v || true
         docker system prune -f
-      args:
-        chdir: /path/to/app/directory
       ignore_errors: true
+
     - name: Create app directory
       file:
         path: /home/ubuntu/qcode


### PR DESCRIPTION
Update the cleanup path to ensure the correct directory is used when stopping and removing existing Docker containers.